### PR TITLE
Express Server Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doctor Swag
 
-This is a node module that functions as an extensible code generator for Swagger 2.0. It is based on wcandillon's excellent module https://github.com/wcandillon/swagger-js-codegen. This module represents a fairly large internal structural change while trying to maintain compatibility with the original module (Swagger 1.x support was dropped).
+This is a node module that functions as an extensible code generator for Swagger 2.0. It is based on wcandillon's excellent module https://github.com/wcandillon/swagger-js-codegen. This module represents a fairly large internal structural change while trying to maintain compatibility with the original module (Swagger 1.x support was dropped). At this point this project can be classified as "Highly Experimental"
 
 ## Additional Features
 * Users swagger-tools to validate the in bound swagger document
@@ -20,7 +20,7 @@ var CodeGen = require('doctorSwag');
 
 var file = 'swagger/spec.json';
 var swagger = JSON.parse(fs.readFileSync(file, 'UTF-8'));
-var nodejsSourceCode = CodeGen({ moduleName: 'TestModule', className: 'Test', swagger: swagger, type: 'node' });
+var nodejsSourceCode = CodeGen({ moduleName: 'TestModule', className: 'Test', swagger: swagger, type: 'nodeJs' });
 var angularTsSourceCode = CodeGen.getAngularCode({ moduleName: 'TestModule', className: 'Test', swagger: swagger, type: 'angularTs' });
 console.log(nodejsSourceCode);
 console.log(angularjsSourceCode);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -33,6 +33,8 @@ function generate(swaggerObj, opts) {
             // Process swagger doc into render vars
             if (result.errors && result.errors.length > 0) {
                 defer.reject(result.errors);
+            } else if (result.warnings && result.warnings.length > 0) {
+                defer.reject(result.warnings);
             }
         } else {
             var data = processSwagger(swaggerObj, opts);

--- a/lib/renderers.js
+++ b/lib/renderers.js
@@ -70,6 +70,12 @@ hb.registerHelper('formatResponse', function(resp) {
 
 });
 
+// Basic utility for manipulating odd formatted input
+hb.registerHelper('lowercase', function(st) {
+    return st.toLowerCase();
+});
+
+//
 function renderFileApi(templateFn, ext, data) {
     var files = {},
         defaultFilename = data.moduleName + ext;
@@ -134,9 +140,20 @@ function renderAngularTs() {
     };
 }
 
+function renderExpress() {
+    var routerTemplate = fs.readFileSync(__dirname + '/../templates/express-router.hb', 'UTF-8'),
+        expressMethodTemplate = fs.readFileSync(__dirname + '/../templates/express-method.hb', 'UTF-8'),
+        routerHb;
+
+    hb.registerPartial('expressMethod', expressMethodTemplate);
+    routerHb = hb.compile(routerTemplate);
+    return _.partial(renderFileApi, routerHb, '.js');
+}
+
 renderers.angularJs = renderAngular;
 renderers.nodeJs = renderNode;
 renderers.angularTs = renderAngularTs;
+renderers.expressJs = renderExpress;
 
 exports = module.exports = {
     register: function(name, renderFn) {

--- a/lib/renderers.js
+++ b/lib/renderers.js
@@ -75,6 +75,13 @@ hb.registerHelper('lowercase', function(st) {
     return st.toLowerCase();
 });
 
+// Express needs modified a variant on path
+hb.registerHelper('expressPath', function(path) {
+    var newPath = path.replace(/\{/g, ':').replace(/\}/g, '');
+
+    return newPath;
+})
+
 //
 function renderFileApi(templateFn, ext, data) {
     var files = {},

--- a/templates/express-method.hb
+++ b/templates/express-method.hb
@@ -1,0 +1,24 @@
+/* {{summary}} */
+router.{{lowercase method}}('{{path}}', function(req, res) {
+    {{#parameters}}
+    {{#if isFormParameter}}var {{camelCaseName}} = req.form['{{name}}'];
+    {{/if}}{{#if isPathParameter}}var {{camelCaseName}} = req.params['{{name}}'];
+    {{/if}}{{#if isBodyParameter}}var {{camelCaseName}} = req.body;
+    {{/if}}
+    {{#if isQueryParameter}}var {{camelCaseName}} = req.query['{{name}}'];{{/if}}
+    {{#required}}// Checking for a non-null value
+    if (!{{camelCaseName}}) {
+        res.status(400).end(JSON.stringify({error: '{{name}} is a required parameter'}));
+        return;
+    } {{/required}}
+    {{/parameters}}
+
+    try {
+        result = handlers.{{methodName}}({{#parameters}}{{camelCaseName}}, {{/parameters}} req.headers);
+        res.send(result);
+    } catch (ex) {
+        // statusCode and json should be apart of the exception
+        res.status(500).end(JSON.parse(ex));
+    }
+});
+

--- a/templates/express-method.hb
+++ b/templates/express-method.hb
@@ -1,24 +1,28 @@
 /* {{summary}} */
 router.{{lowercase method}}('{{expressPath path}}', function(req, res) {
     {{#parameters}}
-    {{#if isFormParameter}}var {{camelCaseName}} = req.form['{{name}}'];
+    {{#if isFormParameter}}var {{camelCaseName}} = req.body['{{name}}'];
     {{/if}}{{#if isPathParameter}}var {{camelCaseName}} = req.params['{{name}}'];
     {{/if}}{{#if isBodyParameter}}var {{camelCaseName}} = req.body;
     {{/if}}
     {{#if isQueryParameter}}var {{camelCaseName}} = req.query['{{name}}'];{{/if}}
     {{#required}}// Checking for a non-null value
     if (!{{camelCaseName}}) {
-        res.status(400).end(JSON.stringify({error: '{{name}} is a required parameter'}));
+        res.status(400).send({error: '{{name}} is a required parameter'});
         return;
     } {{/required}}
     {{/parameters}}
 
     try {
-        result = handlers.{{methodName}}({{#parameters}}{{camelCaseName}}, {{/parameters}} req.headers);
-        res.send(result);
+        handlers.{{methodName}}({{#parameters}}{{camelCaseName}}, {{/parameters}} req.headers)
+        .then(function(result) {
+            res.send(result);
+        }, function(err) {
+            res.status(err.statusCode).send(err.message);
+        });
     } catch (ex) {
         // statusCode and json should be apart of the exception
-        res.status(500).end(JSON.parse(ex));
+        res.status(500).send(ex);
     }
 });
 

--- a/templates/express-method.hb
+++ b/templates/express-method.hb
@@ -1,5 +1,5 @@
 /* {{summary}} */
-router.{{lowercase method}}('{{path}}', function(req, res) {
+router.{{lowercase method}}('{{expressPath path}}', function(req, res) {
     {{#parameters}}
     {{#if isFormParameter}}var {{camelCaseName}} = req.form['{{name}}'];
     {{/if}}{{#if isPathParameter}}var {{camelCaseName}} = req.params['{{name}}'];

--- a/templates/express-router.hb
+++ b/templates/express-router.hb
@@ -1,3 +1,5 @@
+/*jshint sub:true*/
+
 /* * *
  * Generated express router
  *

--- a/templates/express-router.hb
+++ b/templates/express-router.hb
@@ -1,0 +1,16 @@
+/* * *
+ * Generated express router
+ *
+ * Description: {{description}}
+ * Rendered for: {{domain}}
+ */
+
+var express = require('express'),
+    router = express.Router(),
+    handlers = require('./handlers');
+
+{{#methods}}
+{{> expressMethod}}
+{{/methods}}
+
+exports = module.exports = router;


### PR DESCRIPTION
This adds support for Express server generation. To keep it generic, it currently only generates a router that can be plugged into any Express app. The current direction would be to have any `index.js` or app setup files either maintained by hand, or generated by a local doctor-swag plugin. 

The generator is pretty opinionated on the `handlers` module in the fact that you must create a handlers module at the top level for the router file to call into. the goal is to divorce the code you would write in a handler and change it into a more generic function that takes input and produces output. All of the Express mechanics would be either generated or handled in the middleware.
